### PR TITLE
blocktime field response JSON-RPC object field

### DIFF
--- a/models/src/main/java/org/dogej/models/wallet/WalletTransaction.java
+++ b/models/src/main/java/org/dogej/models/wallet/WalletTransaction.java
@@ -23,6 +23,7 @@ public class WalletTransaction {
     private Long blockindex;
     private Double fee;
     private Boolean abandoned;
+    private Long blocktime;
 
     @JsonProperty public String getAccount() {
         return account;
@@ -166,6 +167,14 @@ public class WalletTransaction {
 
     public void setFee(Double fee) {
         this.fee = fee;
+    }
+
+    @JsonProperty public Long getBlocktime() {
+        return blocktime;
+    }
+
+    public void setBlocktime(Long blocktime) {
+        this.blocktime = blocktime;
     }
 
     @Override


### PR DESCRIPTION
There are commands which responds with different JSON-RPC object field sets. Sometimes the field is present, sometimes it is absent, it seems like it depends on configurations but also might depend on other factors. Added blocktime field